### PR TITLE
Fix/#6

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -76,9 +76,9 @@ dotnet_style_allow_statement_immediately_after_block_experimental = true
 #### C# コーディング規則 ####
 
 # var を優先
-csharp_style_var_elsewhere = false:silent
-csharp_style_var_for_built_in_types = false:silent
-csharp_style_var_when_type_is_apparent = false:silent
+csharp_style_var_elsewhere = true:silent
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:silent
 
 # 式のようなメンバー
 csharp_style_expression_bodied_accessors = true
@@ -91,11 +91,11 @@ csharp_style_expression_bodied_operators = false
 csharp_style_expression_bodied_properties = true
 
 # パターン マッチング設定
-csharp_style_pattern_matching_over_as_with_null_check = true
-csharp_style_pattern_matching_over_is_with_cast_check = true
-csharp_style_prefer_extended_property_pattern = true
-csharp_style_prefer_not_pattern = true
-csharp_style_prefer_pattern_matching = true
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_prefer_extended_property_pattern = true:suggestion
+csharp_style_prefer_not_pattern = true:suggestion
+csharp_style_prefer_pattern_matching = true:silent
 csharp_style_prefer_switch_expression = true:suggestion
 
 # Null チェック設定
@@ -223,15 +223,19 @@ dotnet_naming_style.begins_with_i.required_prefix = I
 dotnet_naming_style.begins_with_i.required_suffix = 
 dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
+csharp_style_prefer_primary_constructors = true:suggestion
 
 [*.{cs,vb}]
 tab_width = 4
 indent_size = 4
-dotnet_style_qualification_for_field = true:error
-dotnet_style_qualification_for_property = true:error
-dotnet_style_qualification_for_method = false:warning
-dotnet_style_qualification_for_event = true:warning
+dotnet_style_qualification_for_field = false:error
+dotnet_style_qualification_for_property = false:error
+dotnet_style_qualification_for_method = false:error
+dotnet_style_qualification_for_event = true:error
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
 dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
 dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
 dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+dotnet_code_quality_unused_parameters = all:suggestion
+end_of_line = crlf

--- a/README.md
+++ b/README.md
@@ -22,62 +22,69 @@
 
 ## 🎶簡単な使い方
 ```CSharp
-using SoundMaker.Sounds;
-using SoundMaker.Sounds.Score;
-using SoundMaker.Sounds.SoundChannels;
-using SoundMaker.WaveFile;
-
 namespace YourNamespace;
 public static class YourClass
 {
-	private static void Main()
-	{
-		// サウンドの形式を作成する。
-		var soundFormat = new SoundFormat(SoundMaker.Sounds.SamplingFrequencyType.FourtyEightKHz, SoundMaker.Sounds.BitRateType.SixteenBit, SoundMaker.Sounds.ChannelType.Stereo);
-		StereoWave wave = MakeStereoWave(soundFormat);
+    private static void Main()
+    {
+        // サウンドの形式を作成する。
+        var builder = FormatBuilder.Create()
+            .WithFrequency(48000)
+            .WithBitDepth(16)
+            .WithChannelCount(2);
 
-		// ファイルに書き込む。
-		var sound = new SoundWaveChunk(wave.GetBytes(soundFormat.BitRate));
-		var waveFileFormat = new FormatChunk(SoundMaker.WaveFile.SamplingFrequencyType.FourtyEightKHz, SoundMaker.WaveFile.BitRateType.SixteenBit, SoundMaker.WaveFile.ChannelType.Stereo);
-		var writer = new WaveWriter(waveFileFormat, sound);
-		string filePath = "sample.wav";
-		writer.Write(filePath);
-	}
+        var soundFormat = builder.ToSoundFormat();
+        StereoWave wave = MakeStereoWave(soundFormat);
 
-	private static StereoWave MakeStereoWave(SoundFormat format)
-	{
-		// 一分間の四分音符の個数
-		int tempo = 100;
-		// まず、音のチャンネルを作成する必要がある。
-		// 現段階では矩形波、三角波、疑似三角波、ロービットノイズに対応している。
-		var rightChannel = new SquareSoundChannel(tempo, format, SquareWaveRatio.Point25, PanType.Right);
-		var rightChannel2 = new SquareSoundChannel(tempo, format, SquareWaveRatio.Point125, PanType.Right);
-		var leftChannel = new TriangleSoundChannel(tempo, format, PanType.Left);
+        // ファイルに書き込む。
+        var sound = new SoundWaveChunk(wave.GetBytes(soundFormat.BitRate));
+        var waveFileFormat = builder.ToFormatChunk();
+        var writer = new WaveWriter(waveFileFormat, sound);
+        string filePath = "sample.wav";
+        writer.Write(filePath);
+    }
 
-		// ISoundComponentを実装したクラスのオブジェクトをチャンネルに追加していく。
-		// 現段階では普通の音符、休符、タイ、連符を使うことができる。
-		rightChannel.Add(new Note(Scale.C, 5, LengthType.Eighth, isDotted: true));
-		rightChannel.Add(new Tie(new Note(Scale.D, 5, LengthType.Eighth), LengthType.Eighth));
-		var notes = new List<BasicSoundComponentBase>()
-		{
-			new Note(Scale.E, 5, LengthType.Eighth),
-			new Note(Scale.F, 5, LengthType.Eighth),
-			new Note(Scale.G, 5, LengthType.Eighth),
-		};
-		rightChannel.Add(new Tuplet(notes, LengthType.Quarter));
+    private static StereoWave MakeStereoWave(SoundFormat format)
+    {
+        // 一分間の四分音符の個数
+        int tempo = 100;
+        // まず、音のチャンネルを作成する必要がある。
+        // 現段階では矩形波、三角波、疑似三角波、ロービットノイズに対応している。
+        var rightChannel = new SquareSoundChannel(tempo, format, SquareWaveRatio.Point25, PanType.Right)
+        {
+            // ISoundComponentを実装したクラスのオブジェクトをチャンネルに追加していく。
+            // 現段階では普通の音符、休符、タイ、連符を使うことができる。
+            new Note(Scale.C, 5, LengthType.Eighth, isDotted: true),
+            new Tie(new Note(Scale.D, 5, LengthType.Eighth), LengthType.Eighth),
+            new Tuplet(GetComponents(), LengthType.Quarter)
+        };
+        var rightChannel2 = new SquareSoundChannel(tempo, format, SquareWaveRatio.Point125, PanType.Right)
+        {
+            new Note(Scale.C, 4, LengthType.Eighth, isDotted: true),
+            new Note(Scale.D, 4, LengthType.Quarter),
+            new Rest(LengthType.Quarter)
+        };
+        var leftChannel = new TriangleSoundChannel(tempo, format, PanType.Left)
+        {
+            new Note(Scale.C, 3, LengthType.Eighth, isDotted: true),
+            new Note(Scale.D, 3, LengthType.Quarter),
+            new Rest(LengthType.Quarter)
+        };
 
-		rightChannel2.Add(new Note(Scale.C, 4, LengthType.Eighth, isDotted: true));
-		rightChannel2.Add(new Note(Scale.D, 4, LengthType.Quarter));
-		rightChannel2.Add(new Rest(LengthType.Quarter));
+        var channels = new List<ISoundChannel>() { rightChannel, rightChannel2, leftChannel };
+        // ミックスは'StereoMixer'クラスで行う。 
+        return new StereoMixer(channels).Mix();
+    }
 
-		leftChannel.Add(new Note(Scale.C, 3, LengthType.Eighth, isDotted: true));
-		leftChannel.Add(new Note(Scale.D, 3, LengthType.Quarter));
-		leftChannel.Add(new Rest(LengthType.Quarter));
-
-		var channels = new List<ISoundChannel>() { rightChannel, rightChannel2, leftChannel };
-		// ミックスは'StereoMixer'クラスで行う。 
-		return new StereoMixer(channels).Mix();
-	}
+    private static IReadOnlyList<BasicSoundComponentBase> GetComponents()
+    {
+        return new List<BasicSoundComponentBase>()
+        {
+            new Note(Scale.E, 5, LengthType.Eighth),
+            new Note(Scale.F, 5, LengthType.Eighth),
+            new Note(Scale.G, 5, LengthType.Eighth),
+        };
+    }
 }
 
 
@@ -121,65 +128,70 @@ You can do The following content with this library.
 
 ## 🎶Usage
 ```CSharp
-using SoundMaker.Sounds;
-using SoundMaker.Sounds.Score;
-using SoundMaker.Sounds.SoundChannels;
-using SoundMaker.WaveFile;
-
 namespace YourNamespace;
 public static class YourClass
 {
-	private static void Main()
-	{
-		// make sound format.
-		var soundFormat = new SoundFormat(SoundMaker.Sounds.SamplingFrequencyType.FourtyEightKHz, SoundMaker.Sounds.BitRateType.SixteenBit, SoundMaker.Sounds.ChannelType.Stereo);
-		StereoWave wave = MakeStereoWave(soundFormat);
+    private static void Main()
+    {
+        // Create a sound format.
+        var builder = FormatBuilder.Create()
+            .WithFrequency(48000)
+            .WithBitDepth(16)
+            .WithChannelCount(2);
 
-		// write.
-		var sound = new SoundWaveChunk(wave.GetBytes(soundFormat.BitRate));
-		var waveFileFormat = new FormatChunk(SoundMaker.WaveFile.SamplingFrequencyType.FourtyEightKHz, SoundMaker.WaveFile.BitRateType.SixteenBit, SoundMaker.WaveFile.ChannelType.Stereo);
-		var writer = new WaveWriter(waveFileFormat, sound);
-		string filePath = "sample.wav";
-		writer.Write(filePath);
-	}
+        var soundFormat = builder.ToSoundFormat();
+        StereoWave wave = MakeStereoWave(soundFormat);
 
-	private static StereoWave MakeStereoWave(SoundFormat format)
-	{
-		// number of quarter notes per minute.
-		int tempo = 100;
-		// first, you should make the channel of sound.
-		// can use square wave, triangle wave, pseudo triangle wave and low bit noise wave at this stage.
-		var rightChannel = new SquareSoundChannel(tempo, format, SquareWaveRatio.Point25, PanType.Right);
-		var rightChannel2 = new SquareSoundChannel(tempo, format, SquareWaveRatio.Point125, PanType.Right);
-		var leftChannel = new TriangleSoundChannel(tempo, format, PanType.Left);
+        // Write to a file.
+        var sound = new SoundWaveChunk(wave.GetBytes(soundFormat.BitRate));
+        var waveFileFormat = builder.ToFormatChunk();
+        var writer = new WaveWriter(waveFileFormat, sound);
+        string filePath = "sample.wav";
+        writer.Write(filePath);
+    }
 
-		// add the object implemented 'ISoundComponent' to the channel.
-		// can use Note, Rest, Tuplet, Tie at this stage.
-		rightChannel.Add(new Note(Scale.C, 5, LengthType.Eighth, isDotted: true));
-		rightChannel.Add(new Tie(new Note(Scale.D, 5, LengthType.Eighth), LengthType.Eighth));
-		var notes = new List<BasicSoundComponentBase>()
-		{
-			new Note(Scale.E, 5, LengthType.Eighth),
-			new Note(Scale.F, 5, LengthType.Eighth),
-			new Note(Scale.G, 5, LengthType.Eighth),
-		};
-		rightChannel.Add(new Tuplet(notes, LengthType.Quarter));
+    private static StereoWave MakeStereoWave(SoundFormat format)
+    {
+        // The number of quarter notes per minute
+        int tempo = 100;
+        // First, you need to create sound channels.
+        // Currently, it supports square wave, triangle wave, pseudo-triangle wave, and low-bit noise.
+        var rightChannel = new SquareSoundChannel(tempo, format, SquareWaveRatio.Point25, PanType.Right)
+        {
+            // Add objects of classes that implement ISoundComponent to the channel.
+            // Currently, you can use normal notes, rests, ties, and tuplets.
+            new Note(Scale.C, 5, LengthType.Eighth, isDotted: true),
+            new Tie(new Note(Scale.D, 5, LengthType.Eighth), LengthType.Eighth),
+            new Tuplet(GetComponents(), LengthType.Quarter)
+        };
+        var rightChannel2 = new SquareSoundChannel(tempo, format, SquareWaveRatio.Point125, PanType.Right)
+        {
+            new Note(Scale.C, 4, LengthType.Eighth, isDotted: true),
+            new Note(Scale.D, 4, LengthType.Quarter),
+            new Rest(LengthType.Quarter)
+        };
+        var leftChannel = new TriangleSoundChannel(tempo, format, PanType.Left)
+        {
+            new Note(Scale.C, 3, LengthType.Eighth, isDotted: true),
+            new Note(Scale.D, 3, LengthType.Quarter),
+            new Rest(LengthType.Quarter)
+        };
 
-		rightChannel2.Add(new Note(Scale.C, 4, LengthType.Eighth, isDotted: true));
-		rightChannel2.Add(new Note(Scale.D, 4, LengthType.Quarter));
-		rightChannel2.Add(new Rest(LengthType.Quarter));
+        var channels = new List<ISoundChannel>() { rightChannel, rightChannel2, leftChannel };
+        // Mixing is done by the 'StereoMixer' class. 
+        return new StereoMixer(channels).Mix();
+    }
 
-		leftChannel.Add(new Note(Scale.C, 3, LengthType.Eighth, isDotted: true));
-		leftChannel.Add(new Note(Scale.D, 3, LengthType.Quarter));
-		leftChannel.Add(new Rest(LengthType.Quarter));
-
-		var channels = new List<ISoundChannel>() { rightChannel, rightChannel2, leftChannel };
-		// can mix with StereoMixer class. 
-		return new StereoMixer(channels).Mix();
-	}
+    private static IReadOnlyList<BasicSoundComponentBase> GetComponents()
+    {
+        return new List<BasicSoundComponentBase>()
+        {
+            new Note(Scale.E, 5, LengthType.Eighth),
+            new Note(Scale.F, 5, LengthType.Eighth),
+            new Note(Scale.G, 5, LengthType.Eighth),
+        };
+    }
 }
-
-
 ```
 
 ## 👀Features
@@ -188,7 +200,7 @@ public static class YourClass
 - 48000Hz
 - 44100Hz
 
-**Bit rate**
+**Quantization bit rate**
 - 16bit
 - 8bit
 

--- a/src/SoundMaker/FormatBuilder.cs
+++ b/src/SoundMaker/FormatBuilder.cs
@@ -3,6 +3,9 @@ using SoundMaker.WaveFile;
 using System.Collections.ObjectModel;
 
 namespace SoundMaker;
+/// <summary>
+/// Represents a class used to build SoundFormat and FormatChunk.
+/// </summary>
 public class FormatBuilder
 {
     private FormatBuilder() { }
@@ -28,6 +31,12 @@ public class FormatBuilder
             { 8, (Sounds.BitRateType.EightBit, WaveFile.BitRateType.EightBit) }
         };
 
+        /// <summary>
+        /// sets a bit depth(BitRateType) to format. 量子化ビット数を指定する。
+        /// </summary>
+        /// <param name="bitDepth">value</param>
+        /// <returns>builder</returns>
+        /// <exception cref="ArgumentException">The bitDepth value must be either 8 or 16.</exception>
         public ChannelTypeBuilder WithBitDepth(int bitDepth)
         {
             if (BitRates.TryGetValue(bitDepth, out var setting))
@@ -54,6 +63,12 @@ public class FormatBuilder
             { 44100, (Sounds.SamplingFrequencyType.FourtyFourKHz, WaveFile.SamplingFrequencyType.FourtyFourKHz) }
         };
 
+        /// <summary>
+        /// sets a sampling frequency to format. サンプリング周波数を指定する。
+        /// </summary>
+        /// <param name="frequency">sampling frequency</param>
+        /// <returns>builder</returns>
+        /// <exception cref="ArgumentException">The frequency value must be either 48000 or 44100.</exception>
         public BitDepthBuilder WithFrequency(int frequency)
         {
             if (SamplingFrequencies.TryGetValue(frequency, out var setting))
@@ -80,6 +95,12 @@ public class FormatBuilder
             { 2, (Sounds.ChannelType.Stereo, WaveFile.ChannelType.Stereo) }
         };
 
+        /// <summary>
+        /// sets a count fo channels to format.
+        /// </summary>
+        /// <param name="count">count of channels</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException">The count value must be either 1 or 2.</exception>
         public FormatBuilder WithChannelCount(int count)
         {
             if (Channels.TryGetValue(count, out var setting))
@@ -91,17 +112,29 @@ public class FormatBuilder
         }
     }
 
+    /// <summary>
+    /// create an instance of builder. ビルダのインスタンスを作成する。
+    /// </summary>
+    /// <returns>builder</returns>
     public static SamplingFrequencyBuilder Create()
     {
         var builder = new FormatBuilder();
         return new SamplingFrequencyBuilder(builder);
     }
 
+    /// <summary>
+    /// build to FormatChunk. FormatChunkにビルドする。 
+    /// </summary>
+    /// <returns>FormatChunk</returns>
     public FormatChunk ToFormatChunk()
     {
         return new FormatChunk(this.SamplingFrequencyTypePair.wave, this.BitRateTypePair.wave, this.ChannelTypePair.wave);
     }
 
+    /// <summary>
+    /// build to SoundFormat. SoundFormatにビルドする。
+    /// </summary>
+    /// <returns>SoundFormat</returns>
     public SoundFormat ToSoundFormat()
     {
         return new SoundFormat(this.SamplingFrequencyTypePair.sounds, this.BitRateTypePair.sounds, this.ChannelTypePair.sounds);

--- a/src/SoundMaker/FormatBuilder.cs
+++ b/src/SoundMaker/FormatBuilder.cs
@@ -1,0 +1,109 @@
+﻿using SoundMaker.Sounds;
+using SoundMaker.WaveFile;
+using System.Collections.ObjectModel;
+
+namespace SoundMaker;
+public class FormatBuilder
+{
+    private FormatBuilder() { }
+
+    private (Sounds.BitRateType sounds, WaveFile.BitRateType wave) BitRateTypePair { get; set; }
+
+    private (Sounds.ChannelType sounds, WaveFile.ChannelType wave) ChannelTypePair { get; set; }
+
+    private (Sounds.SamplingFrequencyType sounds, WaveFile.SamplingFrequencyType wave) SamplingFrequencyTypePair { get; set; }
+
+    public class BitDepthBuilder
+    {
+        internal BitDepthBuilder(FormatBuilder builder)
+        {
+            this.Builder = builder;
+        }
+
+        private FormatBuilder Builder { get; }
+
+        private static Dictionary<int, (Sounds.BitRateType sounds, WaveFile.BitRateType wave)> BitRates { get; } = new()
+        {
+            { 16, (Sounds.BitRateType.SixteenBit, WaveFile.BitRateType.SixteenBit) },
+            { 8, (Sounds.BitRateType.EightBit, WaveFile.BitRateType.EightBit) }
+        };
+
+        public ChannelTypeBuilder WithBitDepth(int bitDepth)
+        {
+            if (BitRates.TryGetValue(bitDepth, out var setting))
+            {
+                this.Builder.BitRateTypePair = setting;
+                return new ChannelTypeBuilder(this.Builder);
+            }
+            throw new ArgumentException("The bitDepth value must be either 8 or 16.", nameof(bitDepth));
+        }
+    }
+
+    public class SamplingFrequencyBuilder
+    {
+        internal SamplingFrequencyBuilder(FormatBuilder builder)
+        {
+            this.Builder = builder;
+        }
+
+        private FormatBuilder Builder { get; }
+
+        private static Dictionary<int, (Sounds.SamplingFrequencyType sounds, WaveFile.SamplingFrequencyType wave)> SamplingFrequencies { get; } = new()
+        {
+            { 48000, (Sounds.SamplingFrequencyType.FourtyEightKHz, WaveFile.SamplingFrequencyType.FourtyEightKHz) },
+            { 44100, (Sounds.SamplingFrequencyType.FourtyFourKHz, WaveFile.SamplingFrequencyType.FourtyFourKHz) }
+        };
+
+        public BitDepthBuilder WithFrequency(int frequency)
+        {
+            if (SamplingFrequencies.TryGetValue(frequency, out var setting))
+            {
+                this.Builder.SamplingFrequencyTypePair = setting;
+                return new BitDepthBuilder(this.Builder);
+            }
+            throw new ArgumentException("The frequency value must be either 48000 or 44100.", nameof(frequency));
+        }
+    }
+
+    public class ChannelTypeBuilder
+    {
+        internal ChannelTypeBuilder(FormatBuilder builder)
+        {
+            this.Builder = builder;
+        }
+
+        private FormatBuilder Builder { get; }
+
+        private static Dictionary<int, (Sounds.ChannelType sounds, WaveFile.ChannelType wave)> Channels { get; } = new()
+        {
+            { 1, (Sounds.ChannelType.Monaural, WaveFile.ChannelType.Monaural) },
+            { 2, (Sounds.ChannelType.Stereo, WaveFile.ChannelType.Stereo) }
+        };
+
+        public FormatBuilder WithChannelCount(int count)
+        {
+            if (Channels.TryGetValue(count, out var setting))
+            {
+                this.Builder.ChannelTypePair = setting;
+                return this.Builder;
+            }
+            throw new ArgumentException("The count value must be either 1 or 2.", nameof(count));
+        }
+    }
+
+    public static SamplingFrequencyBuilder Create()
+    {
+        var builder = new FormatBuilder();
+        return new SamplingFrequencyBuilder(builder);
+    }
+
+    public FormatChunk ToFormatChunk()
+    {
+        return new FormatChunk(this.SamplingFrequencyTypePair.wave, this.BitRateTypePair.wave, this.ChannelTypePair.wave);
+    }
+
+    public SoundFormat ToSoundFormat()
+    {
+        return new SoundFormat(this.SamplingFrequencyTypePair.sounds, this.BitRateTypePair.sounds, this.ChannelTypePair.sounds);
+    }
+}

--- a/src/SoundMaker/Sounds/BitRateType.cs
+++ b/src/SoundMaker/Sounds/BitRateType.cs
@@ -1,6 +1,6 @@
 ﻿namespace SoundMaker.Sounds;
 /// <summary>
-/// the type which is expressed bit rate of the sound. 量子化ビット数の種類を表す列挙型
+/// the type which is expressed quantization bit rate of the sound. 量子化ビット数の種類を表す列挙型
 /// </summary>
 public enum BitRateType
 {

--- a/src/SoundMaker/Sounds/IWave.cs
+++ b/src/SoundMaker/Sounds/IWave.cs
@@ -19,14 +19,14 @@ public interface IWave
     /// <summary>
     /// get length of bytes of wave data. 波形データのバイト列の長さを取得するメソッド。
     /// </summary>
-    /// <param name="bitRate">bit rate. ビットレート</param>
+    /// <param name="bitRate">quantization bit rate. 量子化ビット数</param>
     /// <returns>length of bytes of wave data.</returns>
     int GetLengthOfBytes(BitRateType bitRate);
 
     /// <summary>
     /// get the array of bytes of wave data. 波形データのバイト列を取得するメソッド。
     /// </summary>
-    /// <param name="bitRate">bit rate. ビットレート</param>
+    /// <param name="bitRate">quantization bit rate. 量子化ビット数</param>
     /// <returns>bytes of wave data. 波形データのバイト列 : byte[]</returns>
     byte[] GetBytes(BitRateType bitRate);
 }

--- a/src/SoundMaker/Sounds/SoundChannels/ISoundChannel.cs
+++ b/src/SoundMaker/Sounds/SoundChannels/ISoundChannel.cs
@@ -1,7 +1,7 @@
 ﻿using SoundMaker.Sounds.Score;
 
 namespace SoundMaker.Sounds.SoundChannels;
-public interface ISoundChannel
+public interface ISoundChannel : IEnumerable<ISoundComponent>
 {
     /// <summary>
     /// get sound component at index. index番目のサウンドコンポーネントを取得する

--- a/src/SoundMaker/Sounds/SoundChannels/SoundChannelBase.cs
+++ b/src/SoundMaker/Sounds/SoundChannels/SoundChannelBase.cs
@@ -1,5 +1,6 @@
 ﻿
 using SoundMaker.Sounds.Score;
+using System.Collections;
 
 namespace SoundMaker.Sounds.SoundChannels;
 /// <summary>
@@ -115,4 +116,14 @@ public abstract class SoundChannelBase : ISoundChannel
     }
 
     public abstract ushort[] GenerateWave();
+
+    public IEnumerator<ISoundComponent> GetEnumerator()
+    {
+        return this.SoundComponents.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return this.SoundComponents.GetEnumerator();
+    }
 }

--- a/src/SoundMaker/Sounds/SoundFormat.cs
+++ b/src/SoundMaker/Sounds/SoundFormat.cs
@@ -8,7 +8,7 @@ public struct SoundFormat
     /// constructor. コンストラクタ
     /// </summary>
     /// <param name="samplingFrequency">sampling frequency. サンプリング周波数</param>
-    /// <param name="bitRate">bit rate.量子化ビット数</param>
+    /// <param name="bitRate">quantization bit rate. 量子化ビット数</param>
     /// <param name="channel">type of channels count. チャンネル数</param>
     public SoundFormat(SamplingFrequencyType samplingFrequency, BitRateType bitRate, ChannelType channel)
     {
@@ -28,7 +28,7 @@ public struct SoundFormat
     public SamplingFrequencyType SamplingFrequency { get; }
 
     /// <summary>
-    /// bit rate. 量子化ビット数
+    /// quantization bit rate. 量子化ビット数
     /// </summary>
     public BitRateType BitRate { get; }
 }

--- a/src/SoundMaker/WaveFile/BitRateType.cs
+++ b/src/SoundMaker/WaveFile/BitRateType.cs
@@ -1,6 +1,6 @@
 ﻿namespace SoundMaker.WaveFile;
 /// <summary>
-/// the type which is expressed bit rate of the sound. 量子化ビット数の種類を表す列挙型
+/// the type which is expressed quantization bit rate of the sound. 量子化ビット数の種類を表す列挙型
 /// </summary>
 public enum BitRateType : ushort
 {

--- a/src/SoundMaker/WaveFile/FormatChunk.cs
+++ b/src/SoundMaker/WaveFile/FormatChunk.cs
@@ -8,7 +8,7 @@ public struct FormatChunk : IChunk
     /// constructor. コンストラクタ
     /// </summary>
     /// <param name="samplingFrequency">sampling frequency. サンプリング周波数</param>
-    /// <param name="bitRate">bit rate. 量子化ビット数</param>
+    /// <param name="bitRate">quantization bit rate. 量子化ビット数</param>
     /// <param name="channel">type of channels count. チャンネル数</param>
     public FormatChunk(SamplingFrequencyType samplingFrequency, BitRateType bitRate, ChannelType channel)
     {
@@ -36,7 +36,7 @@ public struct FormatChunk : IChunk
     private ushort BlockSize { get; }
 
     /// <summary>
-    /// bit rate. 量子化ビット数
+    /// quantization bit rate. 量子化ビット数
     /// </summary>
     public ushort BitRate { get; }
 

--- a/test/Experiment.cs
+++ b/test/Experiment.cs
@@ -1,0 +1,84 @@
+using SoundMaker;
+using SoundMaker.Sounds;
+using SoundMaker.Sounds.Score;
+using SoundMaker.Sounds.SoundChannels;
+using SoundMaker.WaveFile;
+using Xunit.Abstractions;
+
+namespace SoundMakerTests;
+public class Experiment
+{
+    public Experiment(ITestOutputHelper output)
+    {
+        this.Output = output;
+    }
+
+    private ITestOutputHelper Output { get; }
+
+    [Fact(DisplayName = "README.md‚ÌƒTƒ“ƒvƒ‹")]
+    public void TestReflectedVolume()
+    {
+        Main();
+    }
+
+    private void Main()
+    {
+        // Create a sound format.
+        var builder = FormatBuilder.Create()
+            .WithFrequency(48000)
+            .WithBitDepth(16)
+            .WithChannelCount(2);
+
+        var soundFormat = builder.ToSoundFormat();
+        StereoWave wave = MakeStereoWave(soundFormat);
+
+        // Write to a file.
+        var sound = new SoundWaveChunk(wave.GetBytes(soundFormat.BitRate));
+        var waveFileFormat = builder.ToFormatChunk();
+        var writer = new WaveWriter(waveFileFormat, sound);
+        string filePath = "sample.wav";
+        writer.Write(filePath);
+    }
+
+    private StereoWave MakeStereoWave(SoundFormat format)
+    {
+        // The number of quarter notes per minute
+        int tempo = 100;
+        // First, you need to create sound channels.
+        // Currently, it supports square wave, triangle wave, pseudo-triangle wave, and low-bit noise.
+        var rightChannel = new SquareSoundChannel(tempo, format, SquareWaveRatio.Point25, PanType.Right)
+        {
+            // Add objects of classes that implement ISoundComponent to the channel.
+            // Currently, you can use normal notes, rests, ties, and tuplets.
+            new Note(Scale.C, 5, LengthType.Eighth, isDotted: true),
+            new Tie(new Note(Scale.D, 5, LengthType.Eighth), LengthType.Eighth),
+            new Tuplet(GetComponents(), LengthType.Quarter)
+        };
+        var rightChannel2 = new SquareSoundChannel(tempo, format, SquareWaveRatio.Point125, PanType.Right)
+        {
+            new Note(Scale.C, 4, LengthType.Eighth, isDotted: true),
+            new Note(Scale.D, 4, LengthType.Quarter),
+            new Rest(LengthType.Quarter)
+        };
+        var leftChannel = new TriangleSoundChannel(tempo, format, PanType.Left)
+        {
+            new Note(Scale.C, 3, LengthType.Eighth, isDotted: true),
+            new Note(Scale.D, 3, LengthType.Quarter),
+            new Rest(LengthType.Quarter)
+        };
+
+        var channels = new List<ISoundChannel>() { rightChannel, rightChannel2, leftChannel };
+        // Mixing is done by the 'StereoMixer' class. 
+        return new StereoMixer(channels).Mix();
+    }
+
+    private IReadOnlyList<BasicSoundComponentBase> GetComponents()
+    {
+        return new List<BasicSoundComponentBase>()
+        {
+            new Note(Scale.E, 5, LengthType.Eighth),
+            new Note(Scale.F, 5, LengthType.Eighth),
+            new Note(Scale.G, 5, LengthType.Eighth),
+        };
+    }
+}

--- a/test/IntegrationTests/TestFormatBuilder.cs
+++ b/test/IntegrationTests/TestFormatBuilder.cs
@@ -1,0 +1,30 @@
+﻿using SoundMaker;
+
+namespace SoundMakerTests.IntegrationTests;
+public class TestFormatBuilder
+{
+    [Fact()]
+    public void TestToSoundFormat()
+    {
+        var formatBuilder = FormatBuilder.Create()
+            .WithFrequency(48000)
+            .WithBitDepth(16)
+            .WithChannelCount(2);
+        var result = formatBuilder.ToSoundFormat();
+        Assert.Equal(SoundMaker.Sounds.SamplingFrequencyType.FourtyEightKHz, result.SamplingFrequency);
+        Assert.Equal(SoundMaker.Sounds.BitRateType.SixteenBit, result.BitRate);
+        Assert.Equal(SoundMaker.Sounds.ChannelType.Stereo, result.Channel);
+    }
+
+    [Fact()]
+    public void TestToFormatChunc()
+    {
+        var formatBuilder = FormatBuilder.Create()
+            .WithFrequency(48000)
+            .WithBitDepth(16)
+            .WithChannelCount(2);
+        var result = formatBuilder.ToFormatChunk();
+        Assert.Equal(SoundMaker.WaveFile.SamplingFrequencyType.FourtyEightKHz, (SoundMaker.WaveFile.SamplingFrequencyType)result.SamplingFrequency);
+        Assert.Equal(SoundMaker.WaveFile.BitRateType.SixteenBit, (SoundMaker.WaveFile.BitRateType)result.BitRate);
+    }
+}


### PR DESCRIPTION
# Issues
close #6 

# Overview

- FormatBuilder
```cs
        var builder = FormatBuilder.Create()
            .WithFrequency(48000)
            .WithBitDepth(16)
            .WithChannelCount(2);

        var soundFormat = builder.ToSoundFormat();
        var waveFileFormat = builder.ToFormatChunk();
```

- ISoundChanel implements IEnumerable
```cs
var rightChannel = new SquareSoundChannel(tempo, format, SquareWaveRatio.Point25, PanType.Right)
{
    // Add objects of classes that implement ISoundComponent to the channel.
    // Currently, you can use normal notes, rests, ties, and tuplets.
    new Note(Scale.C, 5, LengthType.Eighth, isDotted: true),
    new Tie(new Note(Scale.D, 5, LengthType.Eighth), LengthType.Eighth),
    new Tuplet(GetComponents(), LengthType.Quarter)
};
```